### PR TITLE
Added bind credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ sudo apt-get install -y python-dev libldap2-dev libsasl2-dev libssl-dev ldap-uti
 | users_ou | yes      |         | OU of the user accounts                                    |
 | host     | yes      |         | Hostname of the LDAP server                                |
 | port     | yes      |         | Port of the LDAP server                                    |
+| bind_user| no       |         | Username for bind authentication                           |
+| bind_pw  | no       |         | Password for bind authentication                           |
 | use_ssl  | no       | false   | Use LDAPS to connect                                       |
 | use_tls  | no       | false   | Start TLS on LDAP to connect                               |
 | cacert   | no       | None    | Path to the CA cert used to validate certificate           |


### PR DESCRIPTION
This PR adds support for authenticated binds.  Most AD environments won't allow anonymous binds.  We need to allow the user to specify their bind credentials for them to able to connect to AD.
