### PR TITLE
debian arch dependat package (jessie)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ WHEELSDIR ?= opt/stackstorm/share/wheels
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1
-	DESTDIR ?= $(CURDIR)/debian/$(ST2_COMPONENT)
+	DESTDIR ?= $(CURDIR)/debian/$(PKG_NAME)
 else
 	REDHAT := 1
 endif
 
 
-.PHONY: all install changelog install_wheel
+.PHONY: all install changelog install_wheel install_deps
 all:
 
-install: changelog install_wheel
+install: changelog install_wheel install_deps
 
 changelog: .stamp-changelog
 .stamp-changelog:
@@ -29,7 +29,7 @@ install_wheel:
 	python setup.py bdist_wheel -d $(DESTDIR)/$(WHEELSDIR)
 
 # This step is arch-dependent and must be called only on prepared environment,
-# it's run inside stackstorm/buildpack container. Invoked from rpm spec.
+# it's run inside stackstorm/buildpack containers.
 install_deps:
 	pip wheel --wheel-dir=$(DESTDIR)/$(WHEELSDIR) -r requirements.txt
 	# Well welcome to enterprise (rhel).

--- a/circle.yml
+++ b/circle.yml
@@ -7,13 +7,14 @@ dependencies:
     - ~/.cache/pip
   override:
     - ? |
+        step 0 docker pull stackstorm/buildpack:jessie
         step 0 docker pull stackstorm/buildpack:centos6
         step 1 docker pull stackstorm/buildpack:centos7
       : parallel: true
 
 machine:
   environment:
-    docker_run:  "docker run -w /src -v ${PWD}/${CIRCLE_PROJECT_REPONAME}:/src"
+    docker_run:  "docker run -w /code/${CIRCLE_PROJECT_REPONAME} -v ${PWD}:/code"
   services:
     - docker
 
@@ -25,7 +26,7 @@ test:
       : parallel: true
   override:
     - ? |
-          step dpkg-buildpackage -b -uc -us
+          step ${docker_run} stackstorm/buildpack:jessie dpkg-buildpackage -b -uc -us
           step cp -r ../st2-auth-ldap_*.{deb,changes} $CIRCLE_ARTIFACTS
           step ${docker_run} stackstorm/buildpack:centos6 rpmbuild -bb rpm/st2-auth-ldap.spec
           step cp -r build/x86_64/st2-auth-ldap-*.rpm $CIRCLE_ARTIFACTS

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Homepage: <insert the upstream URL, if relevant>
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/st2-auth-ldap.git;a=summary
 
 Package: st2-auth-ldap
-Architecture: all
+Architecture: any
 Pre-Depends: st2
-Depends: ${misc:Depends}, st2, python-ldap
+Depends: ${misc:Depends}, st2, libldap2
 Description: LDAP auth backend for st2
   LDAP Authentication Backend for StackStorm Enterprise Edition

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-st2-auth-ldap_0.1-1_all.deb Python optional

--- a/debian/postinst
+++ b/debian/postinst
@@ -20,7 +20,7 @@ set -e
 install_ldap() {
   PIP=/opt/stackstorm/st2/bin/pip
   WHEELSDIR=/opt/stackstorm/share/wheels
-  $PIP install --find-links $WHEELSDIR --quiet st2-enterprise-auth-backend-ldap
+  $PIP install --find-links $WHEELSDIR --no-index --quiet st2-enterprise-auth-backend-ldap
 }
 
 case "$1" in

--- a/rpm/st2-auth-ldap.spec
+++ b/rpm/st2-auth-ldap.spec
@@ -30,7 +30,6 @@ Requires: st2 openldap
 
 %install
   %make_install
-  make DESTDIR=%{buildroot} install_deps
 
 %clean
   rm -rf %{buildroot}


### PR DESCRIPTION
added jessie, same way trusty and wheezy can be fetched. cc: @armab 
