### PR TITLE
Prevent LDAP module removal on upgrade

### DIFF
--- a/rpm/st2-auth-ldap.spec
+++ b/rpm/st2-auth-ldap.spec
@@ -42,7 +42,9 @@ Requires: st2 openldap
   %{pip} install --find-links %{st2wheels} --no-index --quiet st2-enterprise-auth-backend-ldap
 
 %postun
-  echo y | %{pip} uninstall st2-enterprise-auth-backend-ldap 1>/dev/null || :
+  if [ $1 -eq 0 ]; then
+    echo y | %{pip} uninstall st2-enterprise-auth-backend-ldap 1>/dev/null || :
+  fi
 
 %files
   %doc rpm/LICENSE


### PR DESCRIPTION
The `%postun` step gets run at the end of an upgrade (confusing, I know).

If a user has an existing BWC system on CentOS/RHEL, and upgrades, we remove the st2-auth-ldap module. The correct approach is to check how many packages will be left on the system after this operation, and only run the removal step if this is the removal of the final version of st2-auth-ldap.


As a workaround, users can either remove/re-install the package with this:
```
sudo yum remove st2-auth-ldap
sudo yum install bwc-enterprise
```

Or they can just re-run the `%postinst` step:
```
/opt/stackstorm/st2/bin/pip install --find-links /opt/stackstorm/share/wheels --no-index --quiet st2-enterprise-auth-backend-ldap
```

Related issues: https://github.com/StackStorm/st2/issues/3213 and https://github.com/StackStorm/st2-packages/issues/418