### PR TITLE
Fix module upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,7 +20,7 @@ set -e
 install_ldap() {
   PIP=/opt/stackstorm/st2/bin/pip
   WHEELSDIR=/opt/stackstorm/share/wheels
-  $PIP install --find-links $WHEELSDIR --no-index --quiet st2-enterprise-auth-backend-ldap
+  $PIP install --find-links $WHEELSDIR --no-index --quiet --upgrade st2-enterprise-auth-backend-ldap
 }
 
 case "$1" in

--- a/rpm/st2-auth-ldap.spec
+++ b/rpm/st2-auth-ldap.spec
@@ -39,7 +39,7 @@ Requires: st2 openldap
   rm -rf %{buildroot}
 
 %post
-  %{pip} install --find-links %{st2wheels} --no-index --quiet st2-enterprise-auth-backend-ldap
+  %{pip} install --find-links %{st2wheels} --no-index --quiet --upgrade st2-enterprise-auth-backend-ldap
 
 %postun
   if [ $1 -eq 0 ]; then


### PR DESCRIPTION
Add the --upgrade option in the pip command so that the module will be upgraded to the latest version.