### PR TITLE
Pin pip to 9.0.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,6 +36,7 @@ dependencies:
           step docker pull stackstorm/buildpack:$dist
         done
     - |
+        set -e
         PKG_VERSION=$(python setup.py --version 2>/dev/null)
         PKG_RELEASE=$(.circle/packagecloud.sh next-revision trusty ${PKG_VERSION} st2-auth-ldap)
         circlerc_env PKG_VERSION PKG_RELEASE


### PR DESCRIPTION
Turns out we need to pin pip to 9.0.3

Related: https://github.com/StackStorm/st2-dockerfiles/pull/65