### PR TITLE
Fix setuptools version normalization to avoid uglifying like '2.9dev'-> '2.9.dev0'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ from setuptools import setup, find_packages
 from dist_utils import check_pip_version
 from dist_utils import fetch_requirements
 from dist_utils import parse_version_string
+# Monkey patch to avoid version normalization like '2.9dev' -> '2.9.dev0', (https://github.com/pypa/setuptools/issues/308)
+from setuptools.extern.packaging import version
+version.Version = version.LegacyVersion
 
 check_pip_version()
 


### PR DESCRIPTION
Fixes #33

Previously we had package versions like `2.9.dev0` uploaded, while they should be `2.9dev`.
This comes from the `setup.py --version` and setuptools, see https://github.com/pypa/setuptools/issues/308 for more context.

The harm noticed in Docker work we're doing when installing unstable enterprise st2 packages by using pinned version like `2.9dev-*`, see: https://github.com/StackStorm/k8s-st2/pull/42/files#r204836833