### PR TITLE
CircleCI: Fixed workspace attach, rename workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-        at: $ARTIFACTS
+          at: $ARTIFACTS
       - run:
           name: List workspace files
           command: find $ARTIFACTS | sed 's|[^/]*/|  |g'
@@ -120,7 +120,7 @@ jobs:
 
 workflows:
   version: 2
-  deploy-workflow:
+  build-deploy-workflow:
     jobs:
       - build
       - deploy:


### PR DESCRIPTION
Fixes indentation issue in `deploy:` job.

Renames workflow.