### PR TITLE
Don't use env var to attach workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: $ARTIFACTS
+          at: /artifacts
       - run:
           name: List workspace files
           command: find $ARTIFACTS | sed 's|[^/]*/|  |g'


### PR DESCRIPTION
Env vars not supported in `attach_workspace`