### PR TITLE
Suppress pip warnings on uninstall on upgrade

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -20,7 +20,7 @@ set -e
 
 uninstall_ldap() {
   PIP=/opt/stackstorm/st2/bin/pip
-  echo y | $PIP uninstall st2-enterprise-auth-backend-ldap 1>/dev/null || :
+  $PIP uninstall -y --quiet st2-enterprise-auth-backend-ldap 1>/dev/null || :
 }
 
 case "$1" in

--- a/rpm/st2-auth-ldap.spec
+++ b/rpm/st2-auth-ldap.spec
@@ -43,7 +43,7 @@ Requires: st2 openldap
 
 %postun
   if [ $1 -eq 0 ]; then
-    echo y | %{pip} uninstall st2-enterprise-auth-backend-ldap 1>/dev/null || :
+    %{pip} uninstall -y --quiet st2-enterprise-auth-backend-ldap 1>/dev/null || :
   fi
 
 %files


### PR DESCRIPTION
This pull request passes ``--quiet`` flag to ``pip uninstall`` command so it suppresses non fatal warnings on package removal on upgrade (we already pass this flag to ``pip install`` during package installation).

I also updated the command line to use ``-y`` flag so pip runs in command line and non-interactive mode (should be more robust than piping ``y`` to pip stdin).

Resolves #56.