### PR TITLE
Fix unfinished renaming of repo and package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LDAP Authentication Backend for StackStorm Enterprise Edition
+# LDAP authentication backend for StackStorm
 
 ## Requirements
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -20,7 +20,7 @@ set -e
 install_ldap() {
   PIP=/opt/stackstorm/st2/bin/pip
   WHEELSDIR=/opt/stackstorm/share/wheels
-  $PIP install --find-links $WHEELSDIR --no-index --quiet --upgrade st2-enterprise-auth-backend-ldap
+  $PIP install --find-links $WHEELSDIR --no-index --quiet --upgrade st2-auth-ldap
 }
 
 case "$1" in

--- a/debian/postrm
+++ b/debian/postrm
@@ -20,7 +20,7 @@ set -e
 
 uninstall_ldap() {
   PIP=/opt/stackstorm/st2/bin/pip
-  $PIP uninstall -y --quiet st2-enterprise-auth-backend-ldap 1>/dev/null || :
+  $PIP uninstall -y --quiet st2-auth-ldap 1>/dev/null || :
 }
 
 case "$1" in

--- a/rpm/st2-auth-ldap.spec
+++ b/rpm/st2-auth-ldap.spec
@@ -20,7 +20,7 @@ Release:        %{release}
 License:        Apache 2.0
 Summary:        LDAP authentication plugin for StackStorm
 URL:            https://stackstorm.com
-Source0:        st2-auth-backend-ldap
+Source0:        st2-auth-ldap
 
 Requires: st2 openldap
 
@@ -44,11 +44,11 @@ Requires: st2 openldap
   rm -rf %{buildroot}
 
 %post
-  %{pip} install --find-links %{st2wheels} --no-index --quiet --upgrade st2-auth-backend-ldap
+  %{pip} install --find-links %{st2wheels} --no-index --quiet --upgrade st2-auth-ldap
 
 %postun
   if [ $1 -eq 0 ]; then
-    %{pip} uninstall -y --quiet st2-auth-backend-ldap 1>/dev/null || :
+    %{pip} uninstall -y --quiet st2-auth-ldap 1>/dev/null || :
   fi
 
 %files

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ version = parse_version_string(INIT_FILE)
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 
 setup(
-    name='st2-auth-backend-ldap',
+    name='st2-auth-ldap',
     version=version,
     description='StackStorm authentication backend for LDAP.',
     author='StackStorm, Inc.',


### PR DESCRIPTION
The package is renamed to st2-auth-ldap. Remove remaining references to enterprise and also fix any naming referred as st2-auth-backend-ldap.