### PR TITLE
Fix lsb_release error when make rpm on centos system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
     REDHAT := 1
 endif
 
-DEB_DISTRO := $(shell lsb_release -cs)
+DEB_DISTRO := $(shell lsb_release -cs || true)
 REDHAT_DISTRO := $(shell rpm --eval '%{rhel}')
 
 ifeq ($(DEB_DISTRO),)


### PR DESCRIPTION
When running make rpm on CentOS/RHEL system, the make command fails with error saying lsb_release command is not valid. Minor fix here to return true and return empty string. The next command to detect redhat distro will succeed and determine the command is running on CentOS/RHEL.