### PR TITLE
added parameter base_ou_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LDAP authentication backend for StackStorm
-[![LDAP Unit Tests Status](https://circleci.com/gh/StackStorm/st2-auth-ldap/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2-auth-ldap) 
+[![LDAP Unit Tests Status](https://circleci.com/gh/StackStorm/st2-auth-ldap/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2-auth-ldap)
 
 ## Requirements
 
@@ -39,6 +39,7 @@ sudo dnf install python2-devel python3-devel openldap-devel
 | client_options             | no       |                | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                       |
 | cache_user_groups_response | no       | `true`         | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached. |
 | cache_user_groups_ttl      | no       | `120`          | How long (in seconds)                                                                                                          |
+| base_ou_group              | no       | `None`         | Base OU to search for group entries. If not specified will default to None and take value of base_ou                           |
 
 ## Implementation Overview
 

--- a/st2auth_ldap/ldap_backend.py
+++ b/st2auth_ldap/ldap_backend.py
@@ -67,7 +67,7 @@ class LDAPAuthenticationBackend(object):
                  use_ssl=False, use_tls=False, cacert=None, network_timeout=10.0,
                  chase_referrals=False, debug=False, client_options=None,
                  group_dns_check='and', cache_user_groups_response=True,
-                 cache_user_groups_cache_ttl=120, cache_user_groups_cache_max_size=100):
+                 cache_user_groups_cache_ttl=120, cache_user_groups_cache_max_size=100, base_ou_group=None):
         if not bind_dn:
             raise ValueError('Bind DN to query the LDAP server is not provided.')
 
@@ -120,6 +120,11 @@ class LDAPAuthenticationBackend(object):
         self._group_pattern = group_pattern or USER_GROUP_MEMBERSHIP_QUERY
         self._base_ou = base_ou
         self._scope = SEARCH_SCOPES[scope]
+
+        if base_ou_group:
+            self._base_ou_group = base_ou_group
+        else:
+            self._base_ou_group = base_ou
 
         if not group_dns:
             raise ValueError('One or more user groups must be specified.')
@@ -352,7 +357,7 @@ class LDAPAuthenticationBackend(object):
             'username': ldap.filter.escape_filter_chars(username),
         }
         query = self._group_pattern.format(**filter_values)
-        result = connection.search_s(self._base_ou, self._scope, query, [])
+        result = connection.search_s(self._base_ou_group, self._scope, query, [])
 
         if result:
             groups = [entry[0] for entry in result if entry[0] is not None]

--- a/st2auth_ldap/ldap_backend.py
+++ b/st2auth_ldap/ldap_backend.py
@@ -67,7 +67,8 @@ class LDAPAuthenticationBackend(object):
                  use_ssl=False, use_tls=False, cacert=None, network_timeout=10.0,
                  chase_referrals=False, debug=False, client_options=None,
                  group_dns_check='and', cache_user_groups_response=True,
-                 cache_user_groups_cache_ttl=120, cache_user_groups_cache_max_size=100, base_ou_group=None):
+                 cache_user_groups_cache_ttl=120, cache_user_groups_cache_max_size=100,
+                 base_ou_group=None):
         if not bind_dn:
             raise ValueError('Bind DN to query the LDAP server is not provided.')
 

--- a/st2auth_ldap/ldap_backend.py
+++ b/st2auth_ldap/ldap_backend.py
@@ -122,11 +122,7 @@ class LDAPAuthenticationBackend(object):
         self._base_ou = base_ou
         self._scope = SEARCH_SCOPES[scope]
 
-        if base_ou_group:
-            self._base_ou_group = base_ou_group
-        else:
-            self._base_ou_group = base_ou
-
+        self._base_ou_group = base_ou_group or base_ou
         if not group_dns:
             raise ValueError('One or more user groups must be specified.')
 


### PR DESCRIPTION
we had issues with our ldap structure and had to have different base OUs for users and groups. we weren't able to easily solve it with filters. with this change, we default to base_ou for users and groups, but have the option to specify a different one for groups if necessary