### PR TITLE
Allow binding with the LDAP server using user supplied username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ sudo dnf install python2-devel python3-devel openldap-devel
 
 | option                     | required |     default    | description                                                                                                                    |
 |----------------------------|----------|----------------|--------------------------------------------------------------------------------------------------------------------------------|
-| bind_dn                    | yes      |                | DN of the service account to bind with the LDAP server                                                                         |
-| bind_password              | yes      |                | Password of the service account                                                                                                |
+| bind_dn                    | yes      |                | DN of the service account to bind with the LDAP server. Use the {username} placeholder in the string to use the user supplied username.                                                                         |
+| bind_password              | yes      |                | Password of the service account. Use the {password} placeholder in the string to use the user supplied password.                                                                                                |
 | base_ou                    | yes      |                | Base OU to search for user and group entries                                                                                   |
 | group_dns                  | yes      |                | Which groups user must be member of to be granted access (group names are considered case-insensitive)                         |
 | group_dns_check            | no       | `and`          | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups. |

--- a/st2auth_ldap/ldap_backend.py
+++ b/st2auth_ldap/ldap_backend.py
@@ -155,6 +155,12 @@ class LDAPAuthenticationBackend(object):
             # Instantiate connection object and bind with service account.
             try:
                 connection = self._init_connection()
+
+                if self._bind_dn.find('{username}') != -1:
+                    self._bind_dn = self._bind_dn.format(username=username)
+                if self._bind_password.find('{password}') != -1:
+                    self._bind_password = self._bind_password.format(password=password)
+
                 connection.simple_bind_s(self._bind_dn, self._bind_password)
             except Exception:
                 LOG.exception('Failed to bind with "%s".' % self._bind_dn)


### PR DESCRIPTION
The [community contributed LDAP backend](https://github.com/StackStorm/st2-auth-backend-ldap) allows binding with the LDAP server using the user supplied username and password. This pull request adds the same feature here.