### PR TITLE
Ci fail python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
+	@echo "COMPONENT_PYTHONPATH_${COMPONENT_PYTHONPATH}_"
+	@echo "COMPONENTS_WITH_RUNNERS_${COMPONENTS_WITH_RUNNERS}_"
+	@echo "space_char_${space_char}:"
 	test -d $(VIRTUALENV_DIR) || virtualenv $(VIRTUALENV_DIR) -p python3
 
 	# Setup PYTHONPATH in bash activate script...

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	@echo "COMPONENT_PYTHONPATH_${COMPONENT_PYTHONPATH}_"
-	@echo "COMPONENTS_WITH_RUNNERS_${COMPONENTS_WITH_RUNNERS}_"
-	@echo "space_char_${space_char}:"
 	test -d $(VIRTUALENV_DIR) || virtualenv $(VIRTUALENV_DIR) -p python3
 
 	# Setup PYTHONPATH in bash activate script...

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ST2_REPO_BRANCH ?= master
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
 
 # nasty hack to get a space into a variable
-space_char :=
-space_char +=
+empty:=
+space_char:= $(empty) $(empty)
 comma := ,
 COMPONENTS = $(wildcard $(ST2_REPO_PATH)/st2*)
 COMPONENTS_RUNNERS := $(wildcard $(ST2_REPO_PATH)/contrib/runners/*)


### PR DESCRIPTION
The CI runs started to fail, because space_char was being set to '' instead of ' '. 
The hack we used still worked on my CentOS machine.
But amended the way we set the space_char and works on the CircleCI Ubuntu runs and my CentOS machine