### PR TITLE
Refresh package list to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - run:
           name: Download and install dependencies
           command: |
+            sudo apt-get update
             sudo apt-get -y install libldap2-dev libsasl2-dev
             make requirements
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           name: Download and install dependencies
           command: |
+            sudo apt-get update
             sudo apt-get -y install libldap2-dev libsasl2-dev
             make requirements
       - run:


### PR DESCRIPTION
Use apt-get update to refresh package list before attempt to install packages.