### PR TITLE
loosen dependency version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-python-ldap==3.4.0
-cachetools>=2.0.1,<2.1.0
+# python-ldap 3.4.1 adds support for openldap 2.5+
+python-ldap>=3.4.0,<3.5.0
+# cachetools:
+#   - 3 requires python3.4+; 4 requires python3.5+; 5 requires python3.7+
+#   - 3 adds python3.7 support; 3.1 adds python3.8; 4.2 adds python3.9;
+#   - 5.2.1 adds python3.11
+cachetools>=2.0.1,<5.4.0


### PR DESCRIPTION
I could not build python-ldap on one machine that had openldap 2.6.
And the pinned version of cachetools is from 2017 and does not technically support python3.8. Cachetools added support for python3.8 in v3.1.

Also, this is a libraray, so it should not have deps locked down this far anyway. Deps should be locked at an app-level, not at a library level.

So, loosen the requirements. Let the lockfile in the st2 repo handle pinning a precise version.