### PR TITLE
pin GHA runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-test-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We need to pin the GHA runner like we do in the st2 repo.
- https://github.com/StackStorm/st2/pull/5832